### PR TITLE
Update Ruby to 2.3 branch

### DIFF
--- a/platform/backend/backend.md
+++ b/platform/backend/backend.md
@@ -22,7 +22,7 @@
 
 ## Technologies
 
-* Ruby 2.2.x (latest stable)
+* Ruby 2.3.x (latest stable)
 * Ruby On Rails 4.2.x (latest stable)
 * Ruby environment management: [rvm](http://rvm.io)
 


### PR DESCRIPTION
I think that 2.3 branch is enough stable to be new default ruby version.